### PR TITLE
CORE-8162 Update kameleon dependency version.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [me.raynes/fs "1.4.6"]
                  [log4j "1.2.16"]
                  [org.cyverse/clojure-commons "2.8.0"]
-                 [org.cyverse/kameleon "2.8.1"]
+                 [org.cyverse/kameleon "2.8.2-SNAPSHOT"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]
                  [clj-http "2.0.0"]]

--- a/src/facepalm/core.clj
+++ b/src/facepalm/core.clj
@@ -8,7 +8,7 @@
         [kameleon.entities]
         [kameleon.queries]
         [kameleon.sql-reader :only [load-sql-file]]
-        [korma.core]
+        [korma.core :exclude [update]]
         [korma.db]
         [slingshot.slingshot :only [throw+ try+]])
   (:require [clojure.string :as string]


### PR DESCRIPTION
Updated to the `2.8.2-SNAPSHOT` version, so it can add the conversions added by cyverse-de/kameleon#1 and cyverse-de/de-db#1.
