### PR TITLE
CORE-8421 Remove kameleon db version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,6 @@ password). Verify that the '.pgpass' file is formatted correctly and has an
 entry for the desired database. If you want the utility to prompt you for the
 password, be sure to run the utility in the foreground.
 
-### ::incompatible-database-conversion
-
-One of the database conversions in the database tarball has a version number
-that is greater than the maximum compatible database version defined in
-kameleon. Verify that the correct database tarball and facepalm version are
-being used. If everything appears to be correct, contact Core Software to ensure
-that kameleon has been updated correctly.
-
 ### Other Errors
 
 Other errors represent uncaught exceptions. The most likely cause of these

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [me.raynes/fs "1.4.6"]
                  [log4j "1.2.16"]
                  [org.cyverse/clojure-commons "2.8.0"]
-                 [org.cyverse/kameleon "2.8.4-SNAPSHOT"]
+                 [org.cyverse/kameleon "3.0.0"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]
                  [clj-http "2.0.0"]]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [me.raynes/fs "1.4.6"]
                  [log4j "1.2.16"]
                  [org.cyverse/clojure-commons "2.8.0"]
-                 [org.cyverse/kameleon "2.8.2-SNAPSHOT"]
+                 [org.cyverse/kameleon "2.8.4-SNAPSHOT"]
                  [postgresql "9.1-901-1.jdbc4"]
                  [slingshot "0.10.3"]
                  [clj-http "2.0.0"]]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
       (string/trim (:out (sh "git" "rev-parse" "HEAD")))
       ""))
 
-(defproject org.cyverse/facepalm "2.8.1-SNAPSHOT"
+(defproject org.cyverse/facepalm "2.10.0-SNAPSHOT"
   :description "Command-line utility for DE database managment."
   :url "https://github.com/cyverse-de/facepalm"
   :license {:name "BSD"

--- a/resources/error-templates/en-US/incompatible-database-version.fleet
+++ b/resources/error-templates/en-US/incompatible-database-version.fleet
@@ -1,7 +1,0 @@
-
-One of the database conversions in the database tarball is incompatible with
-this version of facepalm.  Please verify that the correct database tarball and
-facepalm versions are being used.
-
-First incompatible version: <(:requested-version data)>
-Highest compatible version: <(:compatible-version data)>

--- a/src/facepalm/core.clj
+++ b/src/facepalm/core.clj
@@ -4,7 +4,6 @@
         [clojure.tools.cli :only [cli]]
         [clojure-commons.file-utils :only [with-temp-dir]]
         [facepalm.error-codes]
-        [kameleon.core]
         [kameleon.queries :only [current-db-version]]
         [kameleon.sql-reader :only [load-sql-file]]
         [korma.core :exclude [update]]
@@ -17,7 +16,7 @@
             [facepalm.conversions :as cnv]
             [kameleon.pgpass :as pgpass]
             [me.raynes.fs :as fs])
-  (:import [java.io File IOException]
+  (:import [java.io IOException]
            [java.sql SQLException]
            [org.apache.log4j BasicConfigurator ConsoleAppender Level
             SimpleLayout]))
@@ -359,15 +358,6 @@
          (drop-while existing-version)
          (take-while wanted-version))))
 
-(defn- validate-update-versions
-  "Validates the list of versions to run database conversions for.  An
-   exception will be thrown if any are not compatible with the current version
-   of kameleon."
-  [versions]
-  (let [compatible-version (compatible-db-version)]
-    (dorun (map (partial incompatible-database-conversion compatible-version)
-                (remove #(<= (compare % compatible-version) 0) versions)))))
-
 (defn- load-cfg
   [opts cfg-name]
   (let [props (ref nil)]
@@ -394,7 +384,6 @@
     (unpack-build-artifact dir (:filename opts))
     (set-conversions opts)
     (let [versions (get-update-versions (get-current-db-version) (:version opts))]
-      (validate-update-versions versions)
       (try+
        (dorun (map (partial do-conversion opts) versions))
        (catch Exception e

--- a/src/facepalm/core.clj
+++ b/src/facepalm/core.clj
@@ -5,8 +5,7 @@
         [clojure-commons.file-utils :only [with-temp-dir]]
         [facepalm.error-codes]
         [kameleon.core]
-        [kameleon.entities]
-        [kameleon.queries]
+        [kameleon.queries :only [current-db-version]]
         [kameleon.sql-reader :only [load-sql-file]]
         [korma.core :exclude [update]]
         [korma.db]
@@ -384,7 +383,7 @@
      (if extra-cfg
        (convert @admin-db-spec (load-cfg opts extra-cfg))
        (convert))
-     (insert version
+     (insert :version
              (values {:version new-version})))))
 
 (defn- update-database

--- a/src/facepalm/error_codes.clj
+++ b/src/facepalm/error_codes.clj
@@ -122,22 +122,6 @@
            :database database
            :user     user}))
 
-(defn incompatible-database-conversion
-  "Throws an exception indicating that a conversion is being done for a database
-   version that is not compatible with the current build of facepalm."
-  [compatible-version requested-version]
-  (throw+ {:type               ::incompatible-database-version
-           :requested-version  requested-version
-           :compatible-version compatible-version}))
-
-(defn error-exit
-  "Prints a message to standard error output and exits with a non-zero exit
-   status."
-  [& strs]
-  (binding [*out* *err*]
-    (println strs)
-    (System/exit 1)))
-
 (defn handle-slingshot-exception
   "Handles a Slingshot exception."
   [m banner]


### PR DESCRIPTION
Since entities have been moved out of kameleon, facepalm no longer needs to validate the version of kameleon against the current db version.

This PR also cleans up kameleon dependencies as part of the cyverse-de/kameleon#6 effort.