### PR TITLE
Support conversions for versions with non-single-digit parts

### DIFF
--- a/src/facepalm/conversions.clj
+++ b/src/facepalm/conversions.clj
@@ -17,13 +17,18 @@
   [fname]
   (first (string/split fname #"\.")))
 
-(defn- split-on-underscore
+(defn- split-on-last-underscore
   [fname]
-  (string/split fname #"_"))
+  ; regex: underscore + negative lookahead specifying that no underscores follow it
+  ; limit of 2 returned strings
+  (string/split fname #"_(?!.*_)" 2))
 
 (defn- dotize
   [vstr]
-  (string/join "." (into [] vstr)))
+  (cond
+    (re-find #"_" vstr) (string/replace vstr #"_" ".")
+    (= (count vstr) 3)  (string/join "." (into [] vstr))
+    :else               (throw (Exception. "Version string must either be three digits or specify dot placement with underscores"))))
 
 (defn- fmt-version
   [[version-str date-str]]
@@ -51,7 +56,7 @@
   (-> fname
       fu/basename
       drop-extension
-      split-on-underscore
+      split-on-last-underscore
       fmt-version
       fmt-date
       db-version))

--- a/src/facepalm/core.clj
+++ b/src/facepalm/core.clj
@@ -347,13 +347,17 @@
       "1.2.0:20120101.01"
       ver)))
 
+(defn- sortable-version-keyfn [version-str]
+  (vec (map #(Integer/parseInt %) (string/split version-str #"[.:]"))))
+
 (defn- get-update-versions
   "Gets the list of versions to run database conversions for."
   [current-version dest-version]
-  (let [sorted-versions  (sort (keys @conversions))
-        dest-version     (or dest-version (last sorted-versions))
-        existing-version #(<= (compare % current-version) 0)
-        wanted-version   #(<= (compare % dest-version) 0)]
+  (let [sorted-versions  (sort-by sortable-version-keyfn (keys @conversions))
+        dest-version     (sortable-version-keyfn (or dest-version (last sorted-versions)))
+        current-version  (sortable-version-keyfn current-version)
+        existing-version #(<= (compare (sortable-version-keyfn %) current-version) 0)
+        wanted-version   #(<= (compare (sortable-version-keyfn %) dest-version) 0)]
     (->> sorted-versions
          (drop-while existing-version)
          (take-while wanted-version))))

--- a/src/facepalm/core.clj
+++ b/src/facepalm/core.clj
@@ -348,7 +348,7 @@
       ver)))
 
 (defn- sortable-version-keyfn [version-str]
-  (vec (map #(Integer/parseInt %) (string/split version-str #"[.:]"))))
+  (mapv #(Integer/parseInt %) (string/split version-str #"[.:]")))
 
 (defn- get-update-versions
   "Gets the list of versions to run database conversions for."


### PR DESCRIPTION
This updates the splitting of filenames as well as sorting to support
this (particularly, at present, for the 2.10.0 version)